### PR TITLE
Associando a gasolina ao tempo

### DIFF
--- a/src/FirstClass/Cenas/Scripts/Chegada.gd
+++ b/src/FirstClass/Cenas/Scripts/Chegada.gd
@@ -3,9 +3,9 @@ extends Area2D
 func _on_Chegada_body_entered(body):
 	if body.name == "Player" or body.name == "Cacamba":
 		if Global.permissao == true:
-			Global.gasolina = 8000
+			Global.gasolina = 150
 			Global.permissao = false
-
+			Global.reset = true
 
 func _on_Metade_area_entered(area):
 	Global.permissao = true

--- a/src/FirstClass/Cenas/Scripts/Gasolina.gd
+++ b/src/FirstClass/Cenas/Scripts/Gasolina.gd
@@ -1,11 +1,16 @@
 extends Node2D
 	
-func _process(delta):
-	Global.gasolina -= 1 #Diminuindo o valor da variável "gasolina" em 1 a cada frame
-	if Global.gasolina < 0:
-		Global.gasolina = 0
-	$ProgressBar.value = Global.gasolina #Definindo o valor da barra de progresso para o valor atual da variável "gasolina"
+func _ready():
+	$ProgressBar.value = Global.gasolina
+	$Timer.wait_time = 150
+	$Timer.start()
 	
-	#Condição que leva para tela de Game Over caso a gasolina chegue a 0
-	if Global.gasolina==0:
-		get_tree().change_scene("res://Cenas/tela_gameover.tscn")
+func _process(delta):
+	Global.gasolina = $Timer.time_left
+	$ProgressBar.value = Global.gasolina
+	
+	if Global.reset == true:
+		$Timer.start()
+		Global.reset = false
+func _on_Timer_timeout():
+	Global.gasolina = 0

--- a/src/FirstClass/Cenas/Scripts/Global.gd
+++ b/src/FirstClass/Cenas/Scripts/Global.gd
@@ -1,8 +1,8 @@
 extends Node
 
-var gasolina = 8000 #armazena o valor da gasolina
+var gasolina = 150 #armazena o valor da gasolina
 var permissao = false #permite o reabastecimento da gasolina de acordo com a distância percorrida pelo jogador no percurso
-
+var reset = false #permite o reabastecimento da gasolina ao fim do percurso
 var points = 0 #armazena a pontuação do jogador
 
 var debuf = false

--- a/src/FirstClass/Cenas/Timer.tscn
+++ b/src/FirstClass/Cenas/Timer.tscn
@@ -42,7 +42,7 @@ margin_right = 1197.0
 margin_bottom = 104.0
 custom_styles/fg = SubResource( 3 )
 custom_styles/bg = SubResource( 2 )
-max_value = 8000.0
+max_value = 150.0
 percent_visible = false
 
 [node name="Gasolina" type="Label" parent="ProgressBar"]
@@ -55,3 +55,9 @@ custom_fonts/font = SubResource( 1 )
 text = "Gasolina"
 align = 1
 valign = 1
+
+[node name="Timer" type="Timer" parent="."]
+wait_time = 150.0
+one_shot = true
+
+[connection signal="timeout" from="Timer" to="." method="_on_Timer_timeout"]

--- a/src/FirstClass/Cenas/carregamento.tscn
+++ b/src/FirstClass/Cenas/carregamento.tscn
@@ -90,7 +90,7 @@ position = Vector2( 646, 368 )
 scale = Vector2( 3, 3 )
 frames = SubResource( 1 )
 animation = "Logo Animada"
-frame = 1
+frame = 13
 playing = true
 
 [node name="ColorRect" type="ColorRect" parent="."]


### PR DESCRIPTION
A gasolina estava decrescendo de acordo com os frames, o que prejudica jogadores com taxas de atualização de tela maiores. Portanto, atrelei o decrescimento da gasolina ao tempo.